### PR TITLE
Recomp (Fix macOS crash)

### DIFF
--- a/.github/workflows/multi-platform.yml
+++ b/.github/workflows/multi-platform.yml
@@ -38,7 +38,6 @@ jobs:
           bindings: weebifying/bindings
           build-config: RelWithDebInfo
           combine: true
-          sdk: 'nightly'
           target: ${{ matrix.config.target }}
 
   package:

--- a/mod.json
+++ b/mod.json
@@ -1,11 +1,11 @@
 {
-	"geode": "3.0.0-beta.1",
+	"geode": "3.1.1",
 	"gd": {
 		"win": "2.206",
 		"android": "2.206",
 		"mac": "2.206"
 	},
-	"version": "v1.0.1",
+	"version": "v1.0.2",
 	"id": "weebify.disable_black_glow",
 	"name": "No Force Glow",
 	"developer": "Weebify",


### PR DESCRIPTION
Fixes a crash on macOS caused by this mod, as it was built with incorrect bindings